### PR TITLE
feat: add pre-commit security pipeline stage

### DIFF
--- a/.github/workflows/PRE-COMMIT-SETUP.md
+++ b/.github/workflows/PRE-COMMIT-SETUP.md
@@ -1,0 +1,133 @@
+# Pre-commit Security Hooks Setup
+
+This repository uses [pre-commit](https://pre-commit.com/) hooks to prevent committing sensitive data, enforce code quality, and maintain security standards.
+
+## What Gets Checked
+
+### Security Checks
+
+- ✅ **Secret Detection**: Detects hardcoded secrets, API keys, tokens using `detect-secrets`
+- ✅ **AWS Credentials**: Prevents committing AWS access keys, secret keys, and real ARNs
+- ✅ **Private Keys**: Detects SSH and other private keys
+- ✅ **Large Files**: Prevents committing files larger than 500KB
+
+### Code Quality Checks
+
+- ✅ **Merge Conflicts**: Catches unresolved merge conflict markers
+- ✅ **YAML/JSON Syntax**: Validates configuration files
+- ✅ **Trailing Whitespace**: Removes unnecessary whitespace
+- ✅ **End of File**: Ensures files end with a newline
+- ✅ **Code Formatting**: Prettier for TypeScript/JavaScript, Black for Python
+
+## Installation
+
+### Prerequisites
+
+- Python 3.11+ (for pre-commit and Python hooks)
+- Node.js 24+ (for JavaScript/TypeScript formatting)
+
+### Quick Setup
+
+```bash
+# Install pre-commit
+pip install pre-commit
+
+# Install the git hooks
+pre-commit install
+
+# (Optional) Run on all files to verify setup
+pre-commit run --all-files
+```
+
+## Usage
+
+### Automatic Checks
+
+Once installed, pre-commit hooks run automatically on `git commit`. If any check fails:
+
+1. The commit will be blocked
+2. You'll see which checks failed and why
+3. Fix the issues and try committing again
+
+### Manual Checks
+
+```bash
+# Run on all files
+pre-commit run --all-files
+
+# Run on specific files
+pre-commit run --files apps/web/src/app/page.tsx
+
+# Run a specific hook
+pre-commit run detect-secrets --all-files
+
+# Skip hooks (NOT RECOMMENDED for security hooks)
+git commit --no-verify
+```
+
+## CI/CD Integration
+
+The same pre-commit hooks run in the GitHub Actions CI/CD pipeline in the `security` job. This ensures:
+
+- No one can bypass security checks by skipping local hooks
+- All pull requests are validated before merge
+- Consistent security standards across all contributors
+
+## Troubleshooting
+
+### False Positives in Secret Detection
+
+If `detect-secrets` flags a false positive:
+
+1. Create a baseline file:
+
+   ```bash
+   detect-secrets scan --baseline .secrets.baseline
+   ```
+
+2. Review and commit the baseline (but be careful!)
+
+### Excluding Files
+
+To exclude specific files or directories, update `.pre-commit-config.yaml`:
+
+```yaml
+hooks:
+  - id: detect-secrets
+    exclude: ^(path/to/exclude/|another/path/)
+```
+
+### Hook Update Issues
+
+If hooks fail after updating:
+
+```bash
+# Clean pre-commit cache
+pre-commit clean
+pre-commit install --install-hooks
+```
+
+## What If I Find Secrets?
+
+If you accidentally committed secrets:
+
+1. **Immediately** rotate/revoke the exposed credentials
+2. Remove them from git history using `git-filter-repo` or BFG Repo-Cleaner
+3. Force push (if allowed) or contact a repo admin
+4. Never rely on simply removing secrets in a new commit - they remain in git history!
+
+## Repository Structure
+
+This monorepo has different tools for different components:
+
+- **Frontend** (`apps/web/`): TypeScript/React with Prettier
+- **Core API** (`services/core-api/`): TypeScript/Node.js with Prettier
+- **AgentCore** (`agentcore/`): Python with Black
+- **Infrastructure** (`infra/`): Has its own `.pre-commit-config.yaml` (separate checks)
+
+## Resources
+
+- [Pre-commit Documentation](https://pre-commit.com/)
+- [Detect Secrets](https://github.com/Yelp/detect-secrets)
+- [Prettier](https://prettier.io/)
+- [Black](https://black.readthedocs.io/)

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -8,30 +8,60 @@ on:
   workflow_dispatch:
     inputs:
       force_rebuild:
-        description: 'Force rebuild all services'
+        description: "Force rebuild all services"
         required: false
         default: false
         type: boolean
 
 env:
   AWS_REGION: us-east-1
-  NODE_VERSION: '24'
-  PYTHON_VERSION: '3.11'
+  NODE_VERSION: "24"
+  PYTHON_VERSION: "3.11"
   # ECR repository names (matches CDK infrastructure naming)
-  ECR_REPO_APP: bidopsai/app      # Frontend
-  ECR_REPO_AGENT: bidopsai/agent  # AgentCore
+  ECR_REPO_APP: bidopsai/app # Frontend
+  ECR_REPO_AGENT: bidopsai/agent # AgentCore
 
 permissions:
-  id-token: write   # Required for requesting the JWT
-  contents: read    # Required for actions/checkout
+  id-token: write # Required for requesting the JWT
+  contents: read # Required for actions/checkout
 
 jobs:
+  # ============================================================================
+  # PRE-COMMIT SECURITY CHECKS
+  # ============================================================================
+  pre-commit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch all history for comparison
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      - name: Run pre-commit on changed files only
+        run: |
+          # For PRs, check files changed in the PR
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            pre-commit run --from-ref origin/${{ github.base_ref }} --to-ref HEAD
+          else
+            # For pushes to main/develop, check files in the last commit
+            pre-commit run --from-ref HEAD~1 --to-ref HEAD
+          fi
+
   # ============================================================================
   # CHANGE DETECTION
   # ============================================================================
   changes:
     name: Detect Changes
     runs-on: ubuntu-latest
+    needs: pre-commit
     outputs:
       app: ${{ steps.changes.outputs.app }}
       agent: ${{ steps.changes.outputs.agent }}
@@ -59,7 +89,7 @@ jobs:
     name: Lint Frontend
     runs-on: ubuntu-latest
     needs: changes
-    if: false  # Temporarily disabled
+    if: false # Temporarily disabled
     defaults:
       run:
         working-directory: apps/web
@@ -71,7 +101,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
+          cache: "npm"
           cache-dependency-path: apps/web/package-lock.json
 
       - name: Install dependencies
@@ -88,7 +118,7 @@ jobs:
     name: Lint AgentCore
     runs-on: ubuntu-latest
     needs: changes
-    if: false  # Temporarily disabled
+    if: false # Temporarily disabled
     defaults:
       run:
         working-directory: agentcore
@@ -100,7 +130,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: agentcore/requirements.txt
 
       - name: Install dependencies
@@ -124,7 +154,7 @@ jobs:
     name: Test Frontend
     runs-on: ubuntu-latest
     needs: changes
-    if: false  # Temporarily disabled
+    if: false # Temporarily disabled
     defaults:
       run:
         working-directory: apps/web
@@ -136,7 +166,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
+          cache: "npm"
           cache-dependency-path: apps/web/package-lock.json
 
       - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,10 @@ agents-core/**/venv/
 agents-core/**/env/
 agents-core/**/.venv/
 
+# Python virtual environments (root level)
+.venv/
+venv/
+
 # ============================================
 # IDE AND EDITORS
 # ============================================
@@ -161,6 +165,7 @@ docker-compose.override.yml
 # TEMPORARY AND BACKUP FILES
 # ============================================
 
+tmp/
 *.tmp
 *.temp
 *.bak

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,58 @@
+# Pre-commit hooks to prevent committing sensitive data
+# Install: pip install pre-commit && pre-commit install
+# Run manually: pre-commit run --all-files
+
+repos:
+  # Detect secrets and sensitive information
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+      - id: detect-secrets
+        exclude: ^(package-lock\.json|node_modules/|\.next/|\.turbo/|docs/|specs/|\.specify/|infra/)
+
+  # Standard pre-commit hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-added-large-files
+        args: ["--maxkb=500"]
+      - id: check-merge-conflict
+      - id: check-yaml
+        args: ["--unsafe"] # Allow custom YAML tags
+        exclude: ^(specs/.*\.yaml|\.specify/|infra/)
+      - id: check-json
+        exclude: ^(package-lock\.json|node_modules/|infra/)
+      - id: trailing-whitespace
+        exclude: ^(\.specify/|\.next/|node_modules/|infra/)
+      - id: end-of-file-fixer
+        exclude: ^(\.specify/|\.next/|node_modules/|infra/)
+      - id: detect-private-key
+
+  # Custom hook to detect AWS credentials and ARNs
+  - repo: local
+    hooks:
+      - id: check-aws-credentials
+        name: Check for AWS credentials and ARNs
+        entry: bash -c 'if grep -rHn --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx" --include="*.py" --include="*.json" --include="*.yaml" --include="*.yml" --exclude-dir=node_modules --exclude-dir=.next --exclude-dir=.turbo --exclude-dir=docs --exclude-dir=specs --exclude-dir=infra -E "(arn:aws:[a-z0-9-]+:[a-z0-9-]+:[0-9]{12}:|AKIA[0-9A-Z]{16}|aws_secret_access_key\s*[=:]|aws_access_key_id\s*[=:])" .; then echo "❌ Found potential AWS credentials or real ARNs in code! Use environment variables or AWS SSM instead."; exit 1; fi'
+        language: system
+        pass_filenames: false
+        always_run: true
+
+  # TypeScript/JavaScript formatting (apps/web and services/core-api)
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.1.0
+    hooks:
+      - id: prettier
+        types_or: [javascript, jsx, ts, tsx, json, yaml, markdown]
+        exclude: ^(package-lock\.json|node_modules/|\.next/|\.turbo/|docs/|specs/|infra/)
+        args: ["--write", "--ignore-unknown"]
+
+  # Python code formatting (agentcore)
+  - repo: https://github.com/psf/black
+    rev: 24.1.1
+    hooks:
+      - id: black
+        language_version: python3.12
+        args: ["--target-version=py312"]
+        files: ^agentcore/
+        exclude: ^infra/


### PR DESCRIPTION
- Add .pre-commit-config.yaml with security hooks for the monorepo
  - Secret detection with detect-secrets
  - AWS credentials and ARN detection
  - Private key detection
  - Code formatting (Prettier for TS/JS, Black for Python)
- Add pre-commit job to CI/CD pipeline
  - Runs before all other jobs as security gate
  - Only checks changed files for efficiency
  - Different logic for PRs vs pushes
- Add PRE-COMMIT-SETUP.md documentation
- Add tmp/ directory to .gitignore

This mirrors the security setup from the infra subrepo.